### PR TITLE
fix: correct grc20 token path

### DIFF
--- a/grc20/staging.json
+++ b/grc20/staging.json
@@ -27,7 +27,7 @@
   },
   {
     "name": "Foo",
-    "pkg_path": "gno.land/r/onbloc/foo",
+    "pkg_path": "gno.land/r/gnoswap/v1/test_token/foo",
     "symbol": "FOO",
     "decimals": 6,
     "chain_id": "staging",
@@ -40,7 +40,7 @@
   },
   {
     "name": "Bar",
-    "pkg_path": "gno.land/r/onbloc/bar",
+    "pkg_path": "gno.land/r/gnoswap/v1/test_token/bar",
     "symbol": "BAR",
     "decimals": 6,
     "chain_id": "staging",
@@ -53,7 +53,7 @@
   },
   {
     "name": "Baz",
-    "pkg_path": "gno.land/r/onbloc/baz",
+    "pkg_path": "gno.land/r/gnoswap/v1/test_token/baz",
     "symbol": "BAZ",
     "decimals": 6,
     "chain_id": "staging",
@@ -66,7 +66,7 @@
   },
   {
     "name": "Qux",
-    "pkg_path": "gno.land/r/onbloc/qux",
+    "pkg_path": "gno.land/r/gnoswap/v1/test_token/qux",
     "symbol": "QUX",
     "decimals": 6,
     "chain_id": "staging",
@@ -92,7 +92,7 @@
   },
   {
     "name": "Onbloc",
-    "pkg_path": "gno.land/r/onbloc/obl",
+    "pkg_path": "gno.land/r/gnoswap/v1/test_token/obl",
     "symbol": "OBL",
     "decimals": 6,
     "chain_id": "staging",
@@ -105,7 +105,7 @@
   },
   {
     "name": "Usd Coin",
-    "pkg_path": "gno.land/r/onbloc/usdc",
+    "pkg_path": "gno.land/r/gnoswap/v1/test_token/usdc",
     "symbol": "USDC",
     "decimals": 6,
     "chain_id": "staging",

--- a/grc20/test4.json
+++ b/grc20/test4.json
@@ -27,7 +27,7 @@
   },
   {
     "name": "Foo",
-    "pkg_path": "gno.land/r/onbloc/foo",
+    "pkg_path": "gno.land/r/gnoswap/v1/test_token/foo",
     "symbol": "FOO",
     "decimals": 6,
     "chain_id": "test4",
@@ -40,7 +40,7 @@
   },
   {
     "name": "Bar",
-    "pkg_path": "gno.land/r/onbloc/bar",
+    "pkg_path": "gno.land/r/gnoswap/v1/test_token/bar",
     "symbol": "BAR",
     "decimals": 6,
     "chain_id": "test4",
@@ -53,7 +53,7 @@
   },
   {
     "name": "Baz",
-    "pkg_path": "gno.land/r/onbloc/baz",
+    "pkg_path": "gno.land/r/gnoswap/v1/test_token/baz",
     "symbol": "BAZ",
     "decimals": 6,
     "chain_id": "test4",
@@ -66,7 +66,7 @@
   },
   {
     "name": "Qux",
-    "pkg_path": "gno.land/r/onbloc/qux",
+    "pkg_path": "gno.land/r/gnoswap/v1/test_token/qux",
     "symbol": "QUX",
     "decimals": 6,
     "chain_id": "test4",
@@ -92,7 +92,7 @@
   },
   {
     "name": "Onbloc",
-    "pkg_path": "gno.land/r/onbloc/obl",
+    "pkg_path": "gno.land/r/gnoswap/v1/test_token/obl",
     "symbol": "OBL",
     "decimals": 6,
     "chain_id": "test4",
@@ -105,7 +105,7 @@
   },
   {
     "name": "Usd Coin",
-    "pkg_path": "gno.land/r/onbloc/usdc",
+    "pkg_path": "gno.land/r/gnoswap/v1/test_token/usdc",
     "symbol": "USDC",
     "decimals": 6,
     "chain_id": "test4",

--- a/grc20/test5.json
+++ b/grc20/test5.json
@@ -27,7 +27,7 @@
   },
   {
     "name": "Foo",
-    "pkg_path": "gno.land/r/onbloc/foo",
+    "pkg_path": "gno.land/r/gnoswap/v1/test_token/foo",
     "symbol": "FOO",
     "decimals": 6,
     "chain_id": "test5",
@@ -40,7 +40,7 @@
   },
   {
     "name": "Bar",
-    "pkg_path": "gno.land/r/onbloc/bar",
+    "pkg_path": "gno.land/r/gnoswap/v1/test_token/bar",
     "symbol": "BAR",
     "decimals": 6,
     "chain_id": "test5",
@@ -53,7 +53,7 @@
   },
   {
     "name": "Baz",
-    "pkg_path": "gno.land/r/onbloc/baz",
+    "pkg_path": "gno.land/r/gnoswap/v1/test_token/baz",
     "symbol": "BAZ",
     "decimals": 6,
     "chain_id": "test5",
@@ -66,7 +66,7 @@
   },
   {
     "name": "Qux",
-    "pkg_path": "gno.land/r/onbloc/qux",
+    "pkg_path": "gno.land/r/gnoswap/v1/test_token/qux",
     "symbol": "QUX",
     "decimals": 6,
     "chain_id": "test5",
@@ -92,7 +92,7 @@
   },
   {
     "name": "Onbloc",
-    "pkg_path": "gno.land/r/onbloc/obl",
+    "pkg_path": "gno.land/r/gnoswap/v1/test_token/obl",
     "symbol": "OBL",
     "decimals": 6,
     "chain_id": "test5",
@@ -105,7 +105,7 @@
   },
   {
     "name": "Usd Coin",
-    "pkg_path": "gno.land/r/onbloc/usdc",
+    "pkg_path": "gno.land/r/gnoswap/v1/test_token/usdc",
     "symbol": "USDC",
     "decimals": 6,
     "chain_id": "test5",

--- a/grc20/test6.json
+++ b/grc20/test6.json
@@ -27,7 +27,7 @@
   },
   {
     "name": "Foo",
-    "pkg_path": "gno.land/r/onbloc/foo",
+    "pkg_path": "gno.land/r/gnoswap/v1/test_token/foo",
     "symbol": "FOO",
     "decimals": 6,
     "chain_id": "test6",
@@ -40,7 +40,7 @@
   },
   {
     "name": "Bar",
-    "pkg_path": "gno.land/r/onbloc/bar",
+    "pkg_path": "gno.land/r/gnoswap/v1/test_token/bar",
     "symbol": "BAR",
     "decimals": 6,
     "chain_id": "test6",
@@ -53,7 +53,7 @@
   },
   {
     "name": "Baz",
-    "pkg_path": "gno.land/r/onbloc/baz",
+    "pkg_path": "gno.land/r/gnoswap/v1/test_token/baz",
     "symbol": "BAZ",
     "decimals": 6,
     "chain_id": "test6",
@@ -66,7 +66,7 @@
   },
   {
     "name": "Qux",
-    "pkg_path": "gno.land/r/onbloc/qux",
+    "pkg_path": "gno.land/r/gnoswap/v1/test_token/qux",
     "symbol": "QUX",
     "decimals": 6,
     "chain_id": "test6",
@@ -92,7 +92,7 @@
   },
   {
     "name": "Onbloc",
-    "pkg_path": "gno.land/r/onbloc/obl",
+    "pkg_path": "gno.land/r/gnoswap/v1/test_token/obl",
     "symbol": "OBL",
     "decimals": 6,
     "chain_id": "test6",
@@ -105,7 +105,7 @@
   },
   {
     "name": "Usd Coin",
-    "pkg_path": "gno.land/r/onbloc/usdc",
+    "pkg_path": "gno.land/r/gnoswap/v1/test_token/usdc",
     "symbol": "USDC",
     "decimals": 6,
     "chain_id": "test6",

--- a/grc20/test7.json
+++ b/grc20/test7.json
@@ -27,7 +27,7 @@
   },
   {
     "name": "Foo",
-    "pkg_path": "gno.land/r/onbloc/foo",
+    "pkg_path": "gno.land/r/gnoswap/v1/test_token/foo",
     "symbol": "FOO",
     "decimals": 6,
     "chain_id": "test7",
@@ -40,7 +40,7 @@
   },
   {
     "name": "Bar",
-    "pkg_path": "gno.land/r/onbloc/bar",
+    "pkg_path": "gno.land/r/gnoswap/v1/test_token/bar",
     "symbol": "BAR",
     "decimals": 6,
     "chain_id": "test7",
@@ -53,7 +53,7 @@
   },
   {
     "name": "Baz",
-    "pkg_path": "gno.land/r/onbloc/baz",
+    "pkg_path": "gno.land/r/gnoswap/v1/test_token/baz",
     "symbol": "BAZ",
     "decimals": 6,
     "chain_id": "test7",
@@ -66,7 +66,7 @@
   },
   {
     "name": "Qux",
-    "pkg_path": "gno.land/r/onbloc/qux",
+    "pkg_path": "gno.land/r/gnoswap/v1/test_token/qux",
     "symbol": "QUX",
     "decimals": 6,
     "chain_id": "test7",
@@ -92,7 +92,7 @@
   },
   {
     "name": "Onbloc",
-    "pkg_path": "gno.land/r/onbloc/obl",
+    "pkg_path": "gno.land/r/gnoswap/v1/test_token/obl",
     "symbol": "OBL",
     "decimals": 6,
     "chain_id": "test7",
@@ -105,7 +105,7 @@
   },
   {
     "name": "Usd Coin",
-    "pkg_path": "gno.land/r/onbloc/usdc",
+    "pkg_path": "gno.land/r/gnoswap/v1/test_token/usdc",
     "symbol": "USDC",
     "decimals": 6,
     "chain_id": "test7",

--- a/grc20/test8.json
+++ b/grc20/test8.json
@@ -27,7 +27,7 @@
   },
   {
     "name": "Foo",
-    "pkg_path": "gno.land/r/onbloc/foo",
+    "pkg_path": "gno.land/r/gnoswap/v1/test_token/foo",
     "symbol": "FOO",
     "decimals": 6,
     "chain_id": "test8",
@@ -40,7 +40,7 @@
   },
   {
     "name": "Bar",
-    "pkg_path": "gno.land/r/onbloc/bar",
+    "pkg_path": "gno.land/r/gnoswap/v1/test_token/bar",
     "symbol": "BAR",
     "decimals": 6,
     "chain_id": "test8",
@@ -53,7 +53,7 @@
   },
   {
     "name": "Baz",
-    "pkg_path": "gno.land/r/onbloc/baz",
+    "pkg_path": "gno.land/r/gnoswap/v1/test_token/baz",
     "symbol": "BAZ",
     "decimals": 6,
     "chain_id": "test8",
@@ -66,7 +66,7 @@
   },
   {
     "name": "Qux",
-    "pkg_path": "gno.land/r/onbloc/qux",
+    "pkg_path": "gno.land/r/gnoswap/v1/test_token/qux",
     "symbol": "QUX",
     "decimals": 6,
     "chain_id": "test8",
@@ -92,7 +92,7 @@
   },
   {
     "name": "Onbloc",
-    "pkg_path": "gno.land/r/onbloc/obl",
+    "pkg_path": "gno.land/r/gnoswap/v1/test_token/obl",
     "symbol": "OBL",
     "decimals": 6,
     "chain_id": "test8",
@@ -105,7 +105,7 @@
   },
   {
     "name": "Usd Coin",
-    "pkg_path": "gno.land/r/onbloc/usdc",
+    "pkg_path": "gno.land/r/gnoswap/v1/test_token/usdc",
     "symbol": "USDC",
     "decimals": 6,
     "chain_id": "test8",

--- a/grc20/test9.json
+++ b/grc20/test9.json
@@ -27,7 +27,7 @@
   },
   {
     "name": "Foo",
-    "pkg_path": "gno.land/r/onbloc/foo",
+    "pkg_path": "gno.land/r/gnoswap/v1/test_token/foo",
     "symbol": "FOO",
     "decimals": 6,
     "chain_id": "test9",
@@ -40,7 +40,7 @@
   },
   {
     "name": "Bar",
-    "pkg_path": "gno.land/r/onbloc/bar",
+    "pkg_path": "gno.land/r/gnoswap/v1/test_token/bar",
     "symbol": "BAR",
     "decimals": 6,
     "chain_id": "test9",
@@ -53,7 +53,7 @@
   },
   {
     "name": "Baz",
-    "pkg_path": "gno.land/r/onbloc/baz",
+    "pkg_path": "gno.land/r/gnoswap/v1/test_token/baz",
     "symbol": "BAZ",
     "decimals": 6,
     "chain_id": "test9",
@@ -66,7 +66,7 @@
   },
   {
     "name": "Qux",
-    "pkg_path": "gno.land/r/onbloc/qux",
+    "pkg_path": "gno.land/r/gnoswap/v1/test_token/qux",
     "symbol": "QUX",
     "decimals": 6,
     "chain_id": "test9",
@@ -92,7 +92,7 @@
   },
   {
     "name": "Onbloc",
-    "pkg_path": "gno.land/r/onbloc/obl",
+    "pkg_path": "gno.land/r/gnoswap/v1/test_token/obl",
     "symbol": "OBL",
     "decimals": 6,
     "chain_id": "test9",
@@ -105,7 +105,7 @@
   },
   {
     "name": "Usd Coin",
-    "pkg_path": "gno.land/r/onbloc/usdc",
+    "pkg_path": "gno.land/r/gnoswap/v1/test_token/usdc",
     "symbol": "USDC",
     "decimals": 6,
     "chain_id": "test9",


### PR DESCRIPTION
 ## Descriptions

This PR updates the `pkg_path` for various tokens to match their actual on-chain contract addresses. This ensures that the token metadata in this repository correctly maps to the deployed contracts, providing an accurate and reliable source of information for dApps and frontends.

## Changes Made

The `pkg_path` for several tokens was updated to align with their deployed contract addresses.

Example:
* Before: `gno.land/r/onbloc/foo`
* After: `gno.land/r/gnoswap/v1/test_token/foo`

### Networks Updated

- staging
- test4
- test5
- test6
- test7
- test8
- test9