### PR TITLE
fix: Update test token paths to use onbloc namespace

### DIFF
--- a/grc20/staging.json
+++ b/grc20/staging.json
@@ -27,7 +27,7 @@
   },
   {
     "name": "Foo",
-    "pkg_path": "gno.land/r/gnoswap/v1/test_token/foo",
+    "pkg_path": "gno.land/r/onbloc/foo",
     "symbol": "FOO",
     "decimals": 6,
     "chain_id": "staging",
@@ -40,7 +40,7 @@
   },
   {
     "name": "Bar",
-    "pkg_path": "gno.land/r/gnoswap/v1/test_token/bar",
+    "pkg_path": "gno.land/r/onbloc/bar",
     "symbol": "BAR",
     "decimals": 6,
     "chain_id": "staging",
@@ -53,7 +53,7 @@
   },
   {
     "name": "Baz",
-    "pkg_path": "gno.land/r/gnoswap/v1/test_token/baz",
+    "pkg_path": "gno.land/r/onbloc/baz",
     "symbol": "BAZ",
     "decimals": 6,
     "chain_id": "staging",
@@ -66,7 +66,7 @@
   },
   {
     "name": "Qux",
-    "pkg_path": "gno.land/r/gnoswap/v1/test_token/qux",
+    "pkg_path": "gno.land/r/onbloc/qux",
     "symbol": "QUX",
     "decimals": 6,
     "chain_id": "staging",
@@ -92,7 +92,7 @@
   },
   {
     "name": "Onbloc",
-    "pkg_path": "gno.land/r/gnoswap/v1/test_token/obl",
+    "pkg_path": "gno.land/r/onbloc/obl",
     "symbol": "OBL",
     "decimals": 6,
     "chain_id": "staging",
@@ -105,7 +105,7 @@
   },
   {
     "name": "Usd Coin",
-    "pkg_path": "gno.land/r/gnoswap/v1/test_token/usdc",
+    "pkg_path": "gno.land/r/onbloc/usdc",
     "symbol": "USDC",
     "decimals": 6,
     "chain_id": "staging",

--- a/grc20/test4.json
+++ b/grc20/test4.json
@@ -27,7 +27,7 @@
   },
   {
     "name": "Foo",
-    "pkg_path": "gno.land/r/gnoswap/v1/test_token/foo",
+    "pkg_path": "gno.land/r/onbloc/foo",
     "symbol": "FOO",
     "decimals": 6,
     "chain_id": "test4",
@@ -40,7 +40,7 @@
   },
   {
     "name": "Bar",
-    "pkg_path": "gno.land/r/gnoswap/v1/test_token/bar",
+    "pkg_path": "gno.land/r/onbloc/bar",
     "symbol": "BAR",
     "decimals": 6,
     "chain_id": "test4",
@@ -53,7 +53,7 @@
   },
   {
     "name": "Baz",
-    "pkg_path": "gno.land/r/gnoswap/v1/test_token/baz",
+    "pkg_path": "gno.land/r/onbloc/baz",
     "symbol": "BAZ",
     "decimals": 6,
     "chain_id": "test4",
@@ -66,7 +66,7 @@
   },
   {
     "name": "Qux",
-    "pkg_path": "gno.land/r/gnoswap/v1/test_token/qux",
+    "pkg_path": "gno.land/r/onbloc/qux",
     "symbol": "QUX",
     "decimals": 6,
     "chain_id": "test4",
@@ -92,7 +92,7 @@
   },
   {
     "name": "Onbloc",
-    "pkg_path": "gno.land/r/gnoswap/v1/test_token/obl",
+    "pkg_path": "gno.land/r/onbloc/obl",
     "symbol": "OBL",
     "decimals": 6,
     "chain_id": "test4",
@@ -105,7 +105,7 @@
   },
   {
     "name": "Usd Coin",
-    "pkg_path": "gno.land/r/gnoswap/v1/test_token/usdc",
+    "pkg_path": "gno.land/r/onbloc/usdc",
     "symbol": "USDC",
     "decimals": 6,
     "chain_id": "test4",

--- a/grc20/test5.json
+++ b/grc20/test5.json
@@ -27,7 +27,7 @@
   },
   {
     "name": "Foo",
-    "pkg_path": "gno.land/r/gnoswap/v1/test_token/foo",
+    "pkg_path": "gno.land/r/onbloc/foo",
     "symbol": "FOO",
     "decimals": 6,
     "chain_id": "test5",
@@ -40,7 +40,7 @@
   },
   {
     "name": "Bar",
-    "pkg_path": "gno.land/r/gnoswap/v1/test_token/bar",
+    "pkg_path": "gno.land/r/onbloc/bar",
     "symbol": "BAR",
     "decimals": 6,
     "chain_id": "test5",
@@ -53,7 +53,7 @@
   },
   {
     "name": "Baz",
-    "pkg_path": "gno.land/r/gnoswap/v1/test_token/baz",
+    "pkg_path": "gno.land/r/onbloc/baz",
     "symbol": "BAZ",
     "decimals": 6,
     "chain_id": "test5",
@@ -66,7 +66,7 @@
   },
   {
     "name": "Qux",
-    "pkg_path": "gno.land/r/gnoswap/v1/test_token/qux",
+    "pkg_path": "gno.land/r/onbloc/qux",
     "symbol": "QUX",
     "decimals": 6,
     "chain_id": "test5",
@@ -92,7 +92,7 @@
   },
   {
     "name": "Onbloc",
-    "pkg_path": "gno.land/r/gnoswap/v1/test_token/obl",
+    "pkg_path": "gno.land/r/onbloc/obl",
     "symbol": "OBL",
     "decimals": 6,
     "chain_id": "test5",
@@ -105,7 +105,7 @@
   },
   {
     "name": "Usd Coin",
-    "pkg_path": "gno.land/r/gnoswap/v1/test_token/usdc",
+    "pkg_path": "gno.land/r/onbloc/usdc",
     "symbol": "USDC",
     "decimals": 6,
     "chain_id": "test5",

--- a/grc20/test6.json
+++ b/grc20/test6.json
@@ -27,7 +27,7 @@
   },
   {
     "name": "Foo",
-    "pkg_path": "gno.land/r/gnoswap/v1/test_token/foo",
+    "pkg_path": "gno.land/r/onbloc/foo",
     "symbol": "FOO",
     "decimals": 6,
     "chain_id": "test6",
@@ -40,7 +40,7 @@
   },
   {
     "name": "Bar",
-    "pkg_path": "gno.land/r/gnoswap/v1/test_token/bar",
+    "pkg_path": "gno.land/r/onbloc/bar",
     "symbol": "BAR",
     "decimals": 6,
     "chain_id": "test6",
@@ -53,7 +53,7 @@
   },
   {
     "name": "Baz",
-    "pkg_path": "gno.land/r/gnoswap/v1/test_token/baz",
+    "pkg_path": "gno.land/r/onbloc/baz",
     "symbol": "BAZ",
     "decimals": 6,
     "chain_id": "test6",
@@ -66,7 +66,7 @@
   },
   {
     "name": "Qux",
-    "pkg_path": "gno.land/r/gnoswap/v1/test_token/qux",
+    "pkg_path": "gno.land/r/onbloc/qux",
     "symbol": "QUX",
     "decimals": 6,
     "chain_id": "test6",
@@ -92,7 +92,7 @@
   },
   {
     "name": "Onbloc",
-    "pkg_path": "gno.land/r/gnoswap/v1/test_token/obl",
+    "pkg_path": "gno.land/r/onbloc/obl",
     "symbol": "OBL",
     "decimals": 6,
     "chain_id": "test6",
@@ -105,7 +105,7 @@
   },
   {
     "name": "Usd Coin",
-    "pkg_path": "gno.land/r/gnoswap/v1/test_token/usdc",
+    "pkg_path": "gno.land/r/onbloc/usdc",
     "symbol": "USDC",
     "decimals": 6,
     "chain_id": "test6",

--- a/grc20/test7.json
+++ b/grc20/test7.json
@@ -27,7 +27,7 @@
   },
   {
     "name": "Foo",
-    "pkg_path": "gno.land/r/gnoswap/v1/test_token/foo",
+    "pkg_path": "gno.land/r/onbloc/foo",
     "symbol": "FOO",
     "decimals": 6,
     "chain_id": "test7",
@@ -40,7 +40,7 @@
   },
   {
     "name": "Bar",
-    "pkg_path": "gno.land/r/gnoswap/v1/test_token/bar",
+    "pkg_path": "gno.land/r/onbloc/bar",
     "symbol": "BAR",
     "decimals": 6,
     "chain_id": "test7",
@@ -53,7 +53,7 @@
   },
   {
     "name": "Baz",
-    "pkg_path": "gno.land/r/gnoswap/v1/test_token/baz",
+    "pkg_path": "gno.land/r/onbloc/baz",
     "symbol": "BAZ",
     "decimals": 6,
     "chain_id": "test7",
@@ -66,7 +66,7 @@
   },
   {
     "name": "Qux",
-    "pkg_path": "gno.land/r/gnoswap/v1/test_token/qux",
+    "pkg_path": "gno.land/r/onbloc/qux",
     "symbol": "QUX",
     "decimals": 6,
     "chain_id": "test7",
@@ -92,7 +92,7 @@
   },
   {
     "name": "Onbloc",
-    "pkg_path": "gno.land/r/gnoswap/v1/test_token/obl",
+    "pkg_path": "gno.land/r/onbloc/obl",
     "symbol": "OBL",
     "decimals": 6,
     "chain_id": "test7",
@@ -105,7 +105,7 @@
   },
   {
     "name": "Usd Coin",
-    "pkg_path": "gno.land/r/gnoswap/v1/test_token/usdc",
+    "pkg_path": "gno.land/r/onbloc/usdc",
     "symbol": "USDC",
     "decimals": 6,
     "chain_id": "test7",

--- a/grc20/test8.json
+++ b/grc20/test8.json
@@ -27,7 +27,7 @@
   },
   {
     "name": "Foo",
-    "pkg_path": "gno.land/r/gnoswap/v1/test_token/foo",
+    "pkg_path": "gno.land/r/onbloc/foo",
     "symbol": "FOO",
     "decimals": 6,
     "chain_id": "test8",
@@ -40,7 +40,7 @@
   },
   {
     "name": "Bar",
-    "pkg_path": "gno.land/r/gnoswap/v1/test_token/bar",
+    "pkg_path": "gno.land/r/onbloc/bar",
     "symbol": "BAR",
     "decimals": 6,
     "chain_id": "test8",
@@ -53,7 +53,7 @@
   },
   {
     "name": "Baz",
-    "pkg_path": "gno.land/r/gnoswap/v1/test_token/baz",
+    "pkg_path": "gno.land/r/onbloc/baz",
     "symbol": "BAZ",
     "decimals": 6,
     "chain_id": "test8",
@@ -66,7 +66,7 @@
   },
   {
     "name": "Qux",
-    "pkg_path": "gno.land/r/gnoswap/v1/test_token/qux",
+    "pkg_path": "gno.land/r/onbloc/qux",
     "symbol": "QUX",
     "decimals": 6,
     "chain_id": "test8",
@@ -92,7 +92,7 @@
   },
   {
     "name": "Onbloc",
-    "pkg_path": "gno.land/r/gnoswap/v1/test_token/obl",
+    "pkg_path": "gno.land/r/onbloc/obl",
     "symbol": "OBL",
     "decimals": 6,
     "chain_id": "test8",
@@ -105,7 +105,7 @@
   },
   {
     "name": "Usd Coin",
-    "pkg_path": "gno.land/r/gnoswap/v1/test_token/usdc",
+    "pkg_path": "gno.land/r/onbloc/usdc",
     "symbol": "USDC",
     "decimals": 6,
     "chain_id": "test8",

--- a/grc20/test9.json
+++ b/grc20/test9.json
@@ -27,7 +27,7 @@
   },
   {
     "name": "Foo",
-    "pkg_path": "gno.land/r/gnoswap/v1/test_token/foo",
+    "pkg_path": "gno.land/r/onbloc/foo",
     "symbol": "FOO",
     "decimals": 6,
     "chain_id": "test9",
@@ -40,7 +40,7 @@
   },
   {
     "name": "Bar",
-    "pkg_path": "gno.land/r/gnoswap/v1/test_token/bar",
+    "pkg_path": "gno.land/r/onbloc/bar",
     "symbol": "BAR",
     "decimals": 6,
     "chain_id": "test9",
@@ -53,7 +53,7 @@
   },
   {
     "name": "Baz",
-    "pkg_path": "gno.land/r/gnoswap/v1/test_token/baz",
+    "pkg_path": "gno.land/r/onbloc/baz",
     "symbol": "BAZ",
     "decimals": 6,
     "chain_id": "test9",
@@ -66,7 +66,7 @@
   },
   {
     "name": "Qux",
-    "pkg_path": "gno.land/r/gnoswap/v1/test_token/qux",
+    "pkg_path": "gno.land/r/onbloc/qux",
     "symbol": "QUX",
     "decimals": 6,
     "chain_id": "test9",
@@ -92,7 +92,7 @@
   },
   {
     "name": "Onbloc",
-    "pkg_path": "gno.land/r/gnoswap/v1/test_token/obl",
+    "pkg_path": "gno.land/r/onbloc/obl",
     "symbol": "OBL",
     "decimals": 6,
     "chain_id": "test9",
@@ -105,7 +105,7 @@
   },
   {
     "name": "Usd Coin",
-    "pkg_path": "gno.land/r/gnoswap/v1/test_token/usdc",
+    "pkg_path": "gno.land/r/onbloc/usdc",
     "symbol": "USDC",
     "decimals": 6,
     "chain_id": "test9",


### PR DESCRIPTION
## Summary
This PR updates all test token package paths in the token resource JSON files to use the correct `onbloc` namespace instead of the incorrect `gnoswap/v1/test_token` paths.

## Changes

### Modified Files
All GRC20 token metadata JSON files:
- `grc20/staging.json`
- `grc20/test4.json`
- `grc20/test5.json`
- `grc20/test6.json`
- `grc20/test7.json`
- `grc20/test8.json`
- `grc20/test9.json`

### Path Updates
Updated all test token package paths:
- ❌ `gno.land/r/gnoswap/v1/test_token/usdc` → ✅ `gno.land/r/onbloc/usdc`
- ❌ `gno.land/r/gnoswap/v1/test_token/bar` → ✅ `gno.land/r/onbloc/bar`
- ❌ `gno.land/r/gnoswap/v1/test_token/baz` → ✅ `gno.land/r/onbloc/baz`
- ❌ `gno.land/r/gnoswap/v1/test_token/foo` → ✅ `gno.land/r/onbloc/foo`
- ❌ `gno.land/r/gnoswap/v1/test_token/obl` → ✅ `gno.land/r/onbloc/obl`
- ❌ `gno.land/r/gnoswap/v1/test_token/qux` → ✅ `gno.land/r/onbloc/qux`
