### PR TITLE
Add JSON schema validation for token resources

### DIFF
--- a/.github/workflows/validate-json.yml
+++ b/.github/workflows/validate-json.yml
@@ -1,0 +1,26 @@
+name: Validate JSON resources
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  validate-json:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install JSON schema validator
+        run: python -m pip install --upgrade pip check-jsonschema
+
+      - name: Validate token resource JSON files
+        run: ./scripts/validate-json.sh

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ As we embrace true decentralization and permissionless platforms on gno.land, we
      - `symbol`: The abbreviation of your token's name, AKA the ticker. Please capitalize all letters.
      - `decimals`: The decimals of your token.
      - `chain_id`: The chain ID of your token.
-     - `description`: A description of your token. You can write up to 1,500 letters.
+     - `description`: A description of your token.
      - `website_url`: The Website URL of your token.
      - `twitter_url`: The Twitter URL of your token.
      - `discord_url`: The Discord URL of your token.
@@ -98,12 +98,12 @@ As we embrace true decentralization and permissionless platforms on gno.land, we
      - `symbol`: The abbreviation your token's name, AKA the ticker. Please capitalize all letters.
      - `decimals`: The decimals of your token.
      - `chain_id`: The chain ID of your token.
-     - `description`: A description of your token. You can write up to 1,500 letters.
+     - `description`: A description of your token.
      - `website_url`: The Website URL of your token.
      - `twitter_url`: The Twitter URL of your token.
      - `discord_url`: The Discord URL of your token.
      - `docs_url`: The Docs URL of your token.
-     - `image`: The location of the image of your token.
+     - `image` (optional): The location of the image of your token.
        - Use the `svg` format and set the file's name to <YOUR-TOKEN-SYMBOL.svg>
        - Add the image file in `/grc20/images` folder.
 
@@ -156,20 +156,21 @@ As we embrace true decentralization and permissionless platforms on gno.land, we
    ```
 
 3. Add information about your token to be displayed
-   - Required information:
-     - `name`: The name of your token to be displayed. Please capitalize the first letter.
-     - `denom`: The denom of your token.
-     - `chain`: The origin chain that the token was issued from.
-     - `symbol`: The abbreviation your token's name, AKA the ticker. Please capitalize all letters.
-     - `decimals`: The decimals of your token.
-     - `description`: A description of your token. You can write up to 1,500 letters.
-     - `website_url`: The Website URL of your token.
-     - `twitter_url`: The Twitter URL of your token.
-     - `discord_url`: The Discord URL of your token.
-     - `docs_url`: The Docs URL of your token.
-     - `image`: The location of the image of your token.
-       - Use the `svg` format and set the file's name to <YOUR-TOKEN-SYMBOL.svg>
-       - Add the image file in `/ibc-native/images` folder.
+    - Required information:
+      - `name`: The name of your token to be displayed. Please capitalize the first letter.
+      - `denom`: The denom of your token.
+      - `chain_id`: The chain ID of your token.
+      - `symbol`: The abbreviation your token's name, AKA the ticker. Please capitalize all letters.
+      - `decimals`: The decimals of your token.
+      - `description`: A description of your token.
+      - `website_url`: The Website URL of your token.
+      - `twitter_url`: The Twitter URL of your token.
+      - `discord_url`: The Discord URL of your token.
+      - `docs_url`: The Docs URL of your token.
+      - `image` (optional): The location of the image of your token.
+        - Use the `svg` format and set the file's name to <YOUR-TOKEN-SYMBOL.svg>
+        - Add the image file in `/ibc-native/images` folder.
+      - `chain` (optional): The origin chain that the token was issued from.
 
 4. Add the token information to `/ibc-native/{CHAIN_ID}.json`
 
@@ -182,6 +183,7 @@ As we embrace true decentralization and permissionless platforms on gno.land, we
   {
     "name": "Cosmos",
     "denom": "uatom",
+    "chain": "cosmoshub",
     "chain_id": "test11",
     "symbol": "ATOM",
     "decimals": 6,
@@ -229,11 +231,11 @@ As we embrace true decentralization and permissionless platforms on gno.land, we
      - `symbol`: The abbreviation your token's name, AKA the ticker. Please capitalize all letters.
      - `decimals`: The decimals of your token.
      - `path`: The path way that your IBC token has traveled through from the origin chain.
-     - `channel`: The channel of the chain that your IBC token is currently on.
-     - `port`: The port of your IBC token.
-     - `image`: The location of the image of your token.
-       - Use the `svg` format and set the file's name to <YOUR-TOKEN-SYMBOL.svg>
-       - Add the image file in `/ibc-tokens/images` folder.
+      - `channel`: The channel of the chain that your IBC token is currently on.
+      - `port`: The port of your IBC token.
+      - `image` (optional): The location of the image of your token.
+        - Use the `svg` format and set the file's name to <YOUR-TOKEN-SYMBOL.svg>
+        - Add the image file in `/ibc-tokens/images` folder.
 
 4. Add the token information to `/ibc-tokens/{CHAIN_ID}.json`
 
@@ -245,16 +247,16 @@ As we embrace true decentralization and permissionless platforms on gno.land, we
 [
   {
     "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
-    "denom": "test11",
+    "chain_id": "test11",
     "origin_chain": "cosmos",
     "origin_denom": "uatom",
     "origin_type": "native",
     "symbol": "ATOM",
     "decimals": 6,
-    "path": "cosmos>osmosis", //The IBC Atom token is on the Osmosis chain
-    "channel": "channel-0", //A channel of the Osmosis chain
+    "path": "cosmos>osmosis",
+    "channel": "channel-0",
     "port": "transfer",
-    "image": "/ibc-tokens/images/atom.svg" //Optional
+    "image": "/ibc-tokens/images/atom.svg"
   }
 ]
 ```
@@ -269,6 +271,26 @@ As we embrace true decentralization and permissionless platforms on gno.land, we
 
 6. Make a pull request from your forked repo to `main`
 </details>
+
+## JSON validation
+
+This repository validates token resource JSON files in pull requests and on pushes to `main`.
+
+- GitHub Action: `.github/workflows/validate-json.yml`
+- Local validation: `./scripts/validate-json.sh`
+- Schema and rule details: [`docs/json-validation-guidelines.md`](./docs/json-validation-guidelines.md)
+
+### Schema coverage
+
+- `gno-native/*.json`
+- `grc20/*.json`
+- `ibc-native/*.json`
+- `ibc-tokens/*.json`
+
+### Notes
+
+- Validation currently focuses on JSON structure, required fields, URLs, and image path format when an image path is provided.
+- Filename and `chain_id` consistency is not enforced yet because some existing files still need normalization.
 
 ## Disclaimer
 

--- a/docs/json-validation-guidelines.md
+++ b/docs/json-validation-guidelines.md
@@ -1,0 +1,48 @@
+# JSON validation guidelines
+
+This repository now validates token resource JSON files with JSON Schema.
+
+## Covered directories
+
+- `gno-native/*.json` → `schemas/gno-native.schema.json`
+- `grc20/*.json` → `schemas/grc20.schema.json`
+- `ibc-native/*.json` → `schemas/ibc-native.schema.json`
+- `ibc-tokens/*.json` → `schemas/ibc-tokens.schema.json`
+
+## What is enforced
+
+- Each file must be a JSON array.
+- Each token entry must use the expected object shape for its directory.
+- Unknown fields are rejected.
+- `decimals` must be a non-negative integer.
+- URL fields accept either a valid URI or an empty string.
+- Image paths must point to the matching directory and use `.svg`.
+- `ibc-tokens.origin_type` is limited to `staking`, `native`, `pool`, `ibc`, `bridge`, `cw20`, or `erc20`.
+
+## What is intentionally not enforced yet
+
+The first version focuses on structure and required fields without breaking the current dataset.
+
+- The filename does not need to match every entry's `chain_id`.
+- Cross-file uniqueness is not checked.
+- Description length is not capped in schema yet.
+
+Those rules can be added later after the existing data is normalized.
+
+## Run validation locally
+
+```shell
+python3 -m pip install check-jsonschema
+./scripts/validate-json.sh
+```
+
+If your Python is externally managed, install the CLI with `uv tool install check-jsonschema` instead.
+
+## Updating schemas
+
+When you add a new required field or change a JSON shape:
+
+1. Update the matching schema in `schemas/`.
+2. Update the contributor guidance in `README.md`.
+3. Run `./scripts/validate-json.sh` locally.
+4. Confirm the GitHub Action passes in your pull request.

--- a/schemas/gno-native.schema.json
+++ b/schemas/gno-native.schema.json
@@ -1,0 +1,102 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "./gno-native.schema.json",
+  "title": "Gno-native token list",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "additionalProperties": false,
+    "required": [
+      "id",
+      "name",
+      "denom",
+      "symbol",
+      "decimals",
+      "chain_id",
+      "description",
+      "website_url",
+      "twitter_url",
+      "discord_url",
+      "docs_url",
+      "image"
+    ],
+    "properties": {
+      "id": {
+        "type": "string",
+        "minLength": 1
+      },
+      "name": {
+        "type": "string",
+        "minLength": 1
+      },
+      "denom": {
+        "type": "string",
+        "minLength": 1
+      },
+      "symbol": {
+        "type": "string",
+        "minLength": 1
+      },
+      "decimals": {
+        "type": "integer",
+        "minimum": 0
+      },
+      "chain_id": {
+        "type": "string",
+        "minLength": 1
+      },
+      "description": {
+        "type": "string",
+        "minLength": 1
+      },
+      "website_url": {
+        "type": "string",
+        "anyOf": [
+          {
+            "const": ""
+          },
+          {
+            "format": "uri"
+          }
+        ]
+      },
+      "twitter_url": {
+        "type": "string",
+        "anyOf": [
+          {
+            "const": ""
+          },
+          {
+            "format": "uri"
+          }
+        ]
+      },
+      "discord_url": {
+        "type": "string",
+        "anyOf": [
+          {
+            "const": ""
+          },
+          {
+            "format": "uri"
+          }
+        ]
+      },
+      "docs_url": {
+        "type": "string",
+        "anyOf": [
+          {
+            "const": ""
+          },
+          {
+            "format": "uri"
+          }
+        ]
+      },
+      "image": {
+        "type": "string",
+        "pattern": "^/gno-native/images/[^/]+\\.svg$"
+      }
+    }
+  }
+}

--- a/schemas/grc20.schema.json
+++ b/schemas/grc20.schema.json
@@ -1,0 +1,104 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "./grc20.schema.json",
+  "title": "GRC20 token list",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "additionalProperties": false,
+    "required": [
+      "name",
+      "pkg_path",
+      "symbol",
+      "decimals",
+      "chain_id",
+      "description",
+      "website_url",
+      "twitter_url",
+      "discord_url",
+      "docs_url",
+      "image"
+    ],
+    "properties": {
+      "name": {
+        "type": "string",
+        "minLength": 1
+      },
+      "pkg_path": {
+        "type": "string",
+        "pattern": "^gno\\.land/.+"
+      },
+      "symbol": {
+        "type": "string",
+        "minLength": 1
+      },
+      "decimals": {
+        "type": "integer",
+        "minimum": 0
+      },
+      "chain_id": {
+        "type": "string",
+        "minLength": 1
+      },
+      "description": {
+        "type": "string",
+        "minLength": 1
+      },
+      "website_url": {
+        "type": "string",
+        "anyOf": [
+          {
+            "const": ""
+          },
+          {
+            "format": "uri"
+          }
+        ]
+      },
+      "twitter_url": {
+        "type": "string",
+        "anyOf": [
+          {
+            "const": ""
+          },
+          {
+            "format": "uri"
+          }
+        ]
+      },
+      "discord_url": {
+        "type": "string",
+        "anyOf": [
+          {
+            "const": ""
+          },
+          {
+            "format": "uri"
+          }
+        ]
+      },
+      "docs_url": {
+        "type": "string",
+        "anyOf": [
+          {
+            "const": ""
+          },
+          {
+            "format": "uri"
+          }
+        ]
+      },
+      "image": {
+        "type": "string",
+        "anyOf": [
+          {
+            "const": ""
+          },
+          {
+            "pattern": "^/grc20/images/[^/]+\\.svg$"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/schemas/ibc-native.schema.json
+++ b/schemas/ibc-native.schema.json
@@ -1,0 +1,108 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "./ibc-native.schema.json",
+  "title": "IBC-native token list",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "additionalProperties": false,
+    "required": [
+      "name",
+      "denom",
+      "chain_id",
+      "symbol",
+      "decimals",
+      "description",
+      "website_url",
+      "twitter_url",
+      "discord_url",
+      "docs_url",
+      "image"
+    ],
+    "properties": {
+      "name": {
+        "type": "string",
+        "minLength": 1
+      },
+      "denom": {
+        "type": "string",
+        "minLength": 1
+      },
+      "chain": {
+        "type": "string",
+        "minLength": 1
+      },
+      "chain_id": {
+        "type": "string",
+        "minLength": 1
+      },
+      "symbol": {
+        "type": "string",
+        "minLength": 1
+      },
+      "decimals": {
+        "type": "integer",
+        "minimum": 0
+      },
+      "description": {
+        "type": "string",
+        "minLength": 1
+      },
+      "website_url": {
+        "type": "string",
+        "anyOf": [
+          {
+            "const": ""
+          },
+          {
+            "format": "uri"
+          }
+        ]
+      },
+      "twitter_url": {
+        "type": "string",
+        "anyOf": [
+          {
+            "const": ""
+          },
+          {
+            "format": "uri"
+          }
+        ]
+      },
+      "discord_url": {
+        "type": "string",
+        "anyOf": [
+          {
+            "const": ""
+          },
+          {
+            "format": "uri"
+          }
+        ]
+      },
+      "docs_url": {
+        "type": "string",
+        "anyOf": [
+          {
+            "const": ""
+          },
+          {
+            "format": "uri"
+          }
+        ]
+      },
+      "image": {
+        "type": "string",
+        "anyOf": [
+          {
+            "const": ""
+          },
+          {
+            "pattern": "^/ibc-native/images/[^/]+\\.svg$"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/schemas/ibc-tokens.schema.json
+++ b/schemas/ibc-tokens.schema.json
@@ -1,0 +1,83 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "./ibc-tokens.schema.json",
+  "title": "IBC token list",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "additionalProperties": false,
+    "required": [
+      "denom",
+      "chain_id",
+      "origin_chain",
+      "origin_denom",
+      "origin_type",
+      "symbol",
+      "decimals",
+      "path",
+      "channel",
+      "port"
+    ],
+    "properties": {
+      "denom": {
+        "type": "string",
+        "minLength": 1
+      },
+      "chain_id": {
+        "type": "string",
+        "minLength": 1
+      },
+      "origin_chain": {
+        "type": "string",
+        "minLength": 1
+      },
+      "origin_denom": {
+        "type": "string",
+        "minLength": 1
+      },
+      "origin_type": {
+        "type": "string",
+        "enum": [
+          "staking",
+          "native",
+          "pool",
+          "ibc",
+          "bridge",
+          "cw20",
+          "erc20"
+        ]
+      },
+      "symbol": {
+        "type": "string",
+        "minLength": 1
+      },
+      "decimals": {
+        "type": "integer",
+        "minimum": 0
+      },
+      "path": {
+        "type": "string",
+        "minLength": 1
+      },
+      "channel": {
+        "type": "string",
+        "minLength": 1
+      },
+      "port": {
+        "type": "string",
+        "minLength": 1
+      },
+      "image": {
+        "type": "string",
+        "anyOf": [
+          {
+            "const": ""
+          },
+          {
+            "pattern": "^/ibc-tokens/images/[^/]+\\.svg$"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/scripts/validate-json.sh
+++ b/scripts/validate-json.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+
+if ! command -v check-jsonschema >/dev/null 2>&1; then
+  printf 'check-jsonschema is required. Install it with:\n'
+  printf '  python3 -m pip install check-jsonschema\n'
+  printf '  # or: uv tool install check-jsonschema\n'
+  exit 127
+fi
+
+check-jsonschema --schemafile "$ROOT_DIR/schemas/gno-native.schema.json" "$ROOT_DIR"/gno-native/*.json
+check-jsonschema --schemafile "$ROOT_DIR/schemas/grc20.schema.json" "$ROOT_DIR"/grc20/*.json
+check-jsonschema --schemafile "$ROOT_DIR/schemas/ibc-native.schema.json" "$ROOT_DIR"/ibc-native/*.json
+check-jsonschema --schemafile "$ROOT_DIR/schemas/ibc-tokens.schema.json" "$ROOT_DIR"/ibc-tokens/*.json
+
+printf 'All JSON files match their schemas.\n'


### PR DESCRIPTION
## Summary
- add directory-specific JSON schemas and a local validation script for the token resource datasets
- add a GitHub Action that validates all token resource JSON files on pull requests and pushes to main
- document the validation workflow and align README examples with the rules CI now enforces

## Validation
- uvx check-jsonschema --schemafile schemas/gno-native.schema.json gno-native/*.json
- uvx check-jsonschema --schemafile schemas/grc20.schema.json grc20/*.json
- uvx check-jsonschema --schemafile schemas/ibc-native.schema.json ibc-native/*.json
- uvx check-jsonschema --schemafile schemas/ibc-tokens.schema.json ibc-tokens/*.json